### PR TITLE
Update README.md: Add link to venv, change source to relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ A simulation environment for testing Nao motions/behaviors/vision(possibly?).
 1. Clone the repository to a convenient location.
 
    `git clone git@github.com:UNSWComputing/PyBullet-Nao-Motion-Editor.git`
-2. Create a virtual environment. _Note: Make sure you have `python 3.7.5` or above installed._
+2. Create a [virtual environment][python3-venv]. _Note: Make sure you have `python 3.7.5` or above installed._
 
    `python -m venv qibullet`
 3. Activate the environment.
 
-   `source /qibullet/bin/activate` on Linux
+   `source ./qibullet/bin/activate` on Linux
    
    `.\qibullet\Scripts\activate` on Windows
 4. Install the required python modules.
@@ -30,3 +30,5 @@ To generate a `.pos` file, close the pybullet window or hit `ESC`. A file with t
 
 ## Notes
 - This is still a work in progress and hasn't been tested sufficiently. So the current interface/workflow might be a bit janky.
+
+[python3-venv]: https://docs.python.org/3/library/venv.html


### PR DESCRIPTION
The absolute path would be relative to the root of the file system, so that's clearly not where the venv is created.

Tested on macOS, but I know the file system paths behave the same for this purpose on macOS and Linux. I had Python 3.11 and was able to upgrade numpy to 1.23.5 as 1.22.x did not help, versions at: https://pypi.org/project/numpy/#history

Then qibullet crashed so that's enough that the venv is working, even if the test fails:

```
17:28:04:~/Projects/PyBullet-Nao-Motion-Editor % python3 test-script.py
pybullet build time: Sep  4 2023 17:25:03
Starting simulation ...
Version = 4.1 INTEL-20.6.4
Vendor = Intel Inc.
Renderer = Intel(R) Iris(TM) Plus Graphics 650
b3Printf: Selected demo: Physics Server
startThreads creating 1 threads.
starting thread 0
started thread 0 
MotionThreadFunc thread started
Spawning Nao ...

The qibullet ressources are not yet installed.

Installing resources for qiBullet

The robot meshes and URDFs will be installed in the /Users/pzrq/.qibullet/1.4.3 folder. You will need to agree to the meshes license in order to be able to install them. Continue the installation (y/n)? y
Installing the meshes and URDFs in the /Users/pzrq/.qibullet/1.4.3 folder...
Python 3.11 detected
Uncompatible version of Python 3
b3Printf: b3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,152]:

b3Printf: URDF file '/Users/pzrq/.qibullet/1.4.3/nao.urdf' not found

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/qibullet/robot_virtual.py", line 49, in loadRobot
    self.robot_model = pybullet.loadURDF(
                       ^^^^^^^^^^^^^^^^^^
pybullet.error: Cannot load URDF file.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pzrq/Projects/PyBullet-Nao-Motion-Editor/test-script.py", line 12, in <module>
    nao = simulation_manager.spawnNao(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/qibullet/simulation_manager.py", line 233, in spawnNao
    nao_virtual.loadRobot(
  File "/usr/local/lib/python3.11/site-packages/qibullet/nao_virtual.py", line 74, in loadRobot
    RobotVirtual.loadRobot(
  File "/usr/local/lib/python3.11/site-packages/qibullet/robot_virtual.py", line 60, in loadRobot
    raise pybullet.error("Cannot load robot model: " + str(e))
pybullet.error: Cannot load robot model: Cannot load URDF file.
numActiveThreads = 0
stopping threads
Thread with taskId 0 exiting
Thread TERMINATED
destroy semaphore
semaphore destroyed
destroy main semaphore
main semaphore destroyed
```